### PR TITLE
Refactoring + Entrypoint applicatif

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,1 @@
-include *.md *.txt LICENSE
+include *.md *.txt LICENSE logs/log.conf

--- a/imprimeti/__init__.py
+++ b/imprimeti/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
 
-import logging.config  
-logging.config.fileConfig(fname = 'logs/log.conf')
+import logging.config
 
+logging.config.fileConfig(fname='logs/log.conf')

--- a/imprimeti/__main__.py
+++ b/imprimeti/__main__.py
@@ -1,35 +1,36 @@
 #!./venv/bin/python
 # -*- coding: utf-8 -*-
 
-import sys
 import logging
-import os
-import time
+import sys
 
-from PyQt5 import QtWidgets, QtCore 
+from PyQt5 import QtWidgets
 
-from .erreurs import InitialisationError
-from .fenetreprincipale import FenetrePrincipale
-from .fenetreparametres import FenetreParametres
-from .etiquetteperso import EtiquetteClient
-from .bradyip300.bradyip300 import BradyIp300
-from . import constantes as const
+import imprimeti.constantes as const
+from imprimeti.bradyip300.bradyip300 import BradyIp300
+from imprimeti.erreurs import InitialisationError
+from imprimeti.etiquetteperso import EtiquetteClient
+from imprimeti.fenetreparametres import FenetreParametres
+from imprimeti.fenetreprincipale import FenetrePrincipale
 
 logger = logging.getLogger(__name__)
 
+
 def afficher_fenetre_parametres_appli_cb():
     """ Affiche la fenètre des paramètres de l'application
-    """    
+    """
     fenetre_parametres.show()
+
 
 def fermer_appli_cb():
     """ Ferme l'application
-    """    
+    """
     application.closeAllWindows()
+
 
 def lancer_impression_cb():
     """ Lance l'impression du fichier généré
-    """    
+    """
     imprimante = BradyIp300(chemin_imprimante=const.BRADY_CHEMIN_PERIPHERIQUE,
                             pas_etiquette=const.BRADY_PAS_ETIQUETTE_MM,
                             decalage_x=const.BRADY_DECALAGE_X_MM,
@@ -39,15 +40,16 @@ def lancer_impression_cb():
     fenetre_principale.initialiser_ihm(description_etiquette)
     fenetre_principale.ui.actionUnitaire.setEnabled(True)
 
-if __name__ == "__main__":
+
+def main():
     application = QtWidgets.QApplication(sys.argv)
     fenetre_principale = FenetrePrincipale()
-    fenetre_parametres =  FenetreParametres()
+    fenetre_parametres = FenetreParametres()
     try:
-        const.chargement_constantes_application()
+        # const.chargement_constantes_application()
         description_etiquette = EtiquetteClient()
     except InitialisationError as erreur:
-        QtWidgets.QMessageBox.critical(fenetre_principale,"Initialisation", erreur.message)  
+        QtWidgets.QMessageBox.critical(fenetre_principale, "Initialisation", erreur.message)
     fenetre_principale.initialiser_ihm(description_etiquette)
     fenetre_principale.ui.actionQuitter.triggered.connect(fermer_appli_cb)
     fenetre_principale.ui.actionConfig.triggered.connect(afficher_fenetre_parametres_appli_cb)
@@ -56,4 +58,6 @@ if __name__ == "__main__":
     logger.info("Demarrage application")
     sys.exit(application.exec_())
 
-    
+
+if __name__ == "__main__":
+    main()

--- a/imprimeti/fenetreprincipale.py
+++ b/imprimeti/fenetreprincipale.py
@@ -56,7 +56,7 @@ class FenetrePrincipale(QtWidgets.QMainWindow):
         """Chargement de la liste des opérateurs depuis la bdd et activation du signal
         """        
         enregistrements = connexion.envoi_requete_bdd("SELECT * FROM operateurs")
-        for operateur in enregistrements:
+        for operateur in enregistrements or []:
             self.ui.comboBoxOperateur.addItem("{} - {} {} {}".format(*operateur[1:5]))
 
         self.ui.comboBoxOperateur.currentIndexChanged[str].connect(self.selectionner_operateur)         

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-PyQt5==5.14
+PyQt5>=5.14
 mysql-connector-python

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-PyQt5
+PyQt5==5.14
 mysql-connector-python

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,8 @@ setup(
     long_description=long_description,
     long_description_content_type='text/mardown',
     license='GNU GPLv3',
+    # https://packaging.python.org/guides/distributing-packages-using-setuptools/#python-requires
+    python_requires='>=3.6',
     packages=find_packages(),
     entry_points={
         'console_scripts': [

--- a/setup.py
+++ b/setup.py
@@ -12,11 +12,16 @@ setup(
     name='labelprintermanager',
     version='1.0',
     author='Romuald Dugied',
-    author_email = 'romuald.dugied@gmail.com',
+    author_email='romuald.dugied@gmail.com',
     url='https://github.com/RomualdDugied/labelprintermanager',
     description='Logiciel impression etiquette',
     long_description=long_description,
     long_description_content_type='text/mardown',
     license='GNU GPLv3',
-    packages=find_packages(),    
+    packages=find_packages(),
+    entry_points={
+        'console_scripts': [
+            'imprimeti=imprimeti.__main__:main'
+        ],
+    }
 )


### PR DESCRIPTION
Mini PR pour refactorer un peu et permettre une utilisation par un tiers dev ;-)
J'ai rajouté/refactoré:
- des précisions sur les versions des packages (j'ai supposé que tu étais en Python 3.6.9 au moins)
- changer au moins sur dans `__main__.py` la stratégie d'import (il faut éviter les imports relatifs)
- un support pour installer l'application via `pip` 
- un entrypoint sur l'application `imprimeti`:
![image](https://user-images.githubusercontent.com/7001058/102361927-142ba580-3fb4-11eb-9e3f-078fa6e154da.png)
